### PR TITLE
Update viomi-root.sh

### DIFF
--- a/viomi-root.sh
+++ b/viomi-root.sh
@@ -132,7 +132,7 @@ function wait_for_adb_shell() {
 function install_dropbear() {
   ip=$1
   filename=dropbear_2015.71-2_sunxi.ipk
-  wget "https://itooktheredpill.irgendwo.org/static/2020/$filename" -O $filename
+  wget "https://itooktheredpill.irgendwo.org/static/2020/$filename" -O $filename '--no-check-certificate'
   echo "6d21911b91505fd781dc2c2ad1920dfbb72132d7adb614cc5d2fb1cc5e29c8de  $filename" > dropbear.sha256
   sha256sum -c dropbear.sha256 || exit
   adb push $filename /tmp


### PR DESCRIPTION
'--no-check-certificate' added (fixes the dropbear cert error)